### PR TITLE
Init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # fastify-response-validation
 
+![Node.js CI](https://github.com/fastify/fastify-response-validation/workflows/Node.js%20CI/badge.svg)  [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+
+
 A simple plugin that enables response validation for Fastify.  
 The use of this plugin will slow down your overall performances, so we suggest using it only during development.
 
@@ -46,7 +49,7 @@ fastify.inject({
 If you want to override the default [ajv](https://www.npmjs.com/package/ajv) configuration, you can do that by using the `ajv` option.
 ```js
 // Default configuration:
-//     coerceTypes: false
+//    coerceTypes: false
 //    useDefaults: true
 //    removeAdditional: true
 //    allErrors: true

--- a/README.md
+++ b/README.md
@@ -62,5 +62,33 @@ fastify.register(require('fastify-response-validation'), {
 })
 ```
 
+By default the response validation is enabled on every route that has a response schema defined, if needed, you can disable it all together with `responseValidation: false`:
+```js
+fastify.register(require('fastify-response-validation'), {
+  responseValidation: false
+})
+```
+Or you can disable a specific route with the same option:
+```js
+fastify.route({
+  method: 'GET',
+  path: '/',
+  responseValidation: false,
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          answer: { type: 'number' }
+        }
+      }
+    }
+  },
+  handler: async (req, reply) => {
+    return { answer: '42' }
+  }
+})
+```
+
 ## License
 [MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # fastify-response-validation
+
+A simple plugin that enables response validation for Fastify.  
+The use of this plugin will slow down your overall performances, so we suggest using it only during development.
+
+## Install
+```
+npm i fastify-response-validation
+```
+
+## Usage
+You just need to register the plugin and you will have response validation enabled.
+
+```js
+const fastify = require('fastify')()
+
+fastify.register(require('fastify-response-validation'))
+
+fastify.route({
+  method: 'GET',
+  path: '/',
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          answer: { type: 'number' }
+        }
+      }
+    }
+  },
+  handler: async (req, reply) => {
+    return { answer: '42' }
+  }
+})
+
+fastify.inject({
+  method: 'GET',
+  path: '/'
+}, (err, res) => {
+  if (err) throw err
+  console.log(res.payload)
+})
+```
+
+If you want to override the default [ajv](https://www.npmjs.com/package/ajv) configuration, you can do that by using the `ajv` option.
+```js
+// Default configuration:
+//     coerceTypes: false
+//    useDefaults: true
+//    removeAdditional: true
+//    allErrors: true
+//    nullable: true
+
+fastify.register(require('fastify-response-validation'), {
+  ajv: {
+    coerceTypes: true
+  }
+})
+```
+
+## License
+[MIT](./LICENSE)

--- a/example.js
+++ b/example.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const fastify = require('fastify')()
+
+fastify.register(require('./'))
+
+fastify.route({
+  method: 'GET',
+  path: '/',
+  schema: {
+    response: {
+      '2xx': {
+        type: 'object',
+        properties: {
+          answer: { type: 'number' }
+        }
+      }
+    }
+  },
+  handler: async (req, reply) => {
+    return { answer: '42' }
+  }
+})
+
+fastify.inject({
+  method: 'GET',
+  path: '/'
+}, (err, res) => {
+  if (err) throw err
+  console.log(res.payload)
+})

--- a/index.js
+++ b/index.js
@@ -12,9 +12,12 @@ function validateResponse (fastify, opts, next) {
     nullable: true
   }, opts.ajv))
 
-  fastify.addHook('onRoute', onRoute)
+  if (opts.responseValidation !== false) {
+    fastify.addHook('onRoute', onRoute)
+  }
 
   function onRoute (opts) {
+    if (opts.responseValidation === false) return
     if (opts.schema && opts.schema.response) {
       opts.preSerialization = opts.preSerialization || []
       opts.preSerialization.push(buildHook(opts.schema.response))

--- a/index.js
+++ b/index.js
@@ -60,4 +60,7 @@ function schemaErrorsText (errors) {
   return text.slice(0, -separator.length)
 }
 
-module.exports = fp(validateResponse)
+module.exports = fp(validateResponse, {
+  fastify: '>=2.0.0',
+  name: 'fastify-response-validation'
+})

--- a/index.js
+++ b/index.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const fp = require('fastify-plugin')
+const Ajv = require('ajv')
+
+function validateResponse (fastify, opts, next) {
+  const ajv = new Ajv(Object.assign({
+    coerceTypes: false,
+    useDefaults: true,
+    removeAdditional: true,
+    allErrors: true,
+    nullable: true
+  }, opts.ajv))
+
+  fastify.addHook('onRoute', onRoute)
+
+  function onRoute (opts) {
+    if (opts.schema && opts.schema.response) {
+      opts.preSerialization = opts.preSerialization || []
+      opts.preSerialization.push(buildHook(opts.schema.response))
+    }
+  }
+
+  function buildHook (schema) {
+    const statusCodes = {}
+    for (const statusCode in schema) {
+      statusCodes[statusCode] = ajv.compile(schema[statusCode])
+    }
+
+    return preSerialization
+
+    function preSerialization (req, reply, payload, next) {
+      var validate = statusCodes[reply.statusCode] || statusCodes[(reply.statusCode + '')[0] + 'xx']
+      if (validate !== undefined) {
+        var valid = validate(payload)
+        if (!valid) {
+          var err = new Error(schemaErrorsText(validate.errors))
+          err.validation = validate.errors
+          reply.code(500)
+          return next(err)
+        }
+      }
+      next()
+    }
+  }
+
+  next()
+}
+
+function schemaErrorsText (errors) {
+  var text = ''
+  var separator = ', '
+  for (var i = 0; i < errors.length; i++) {
+    var e = errors[i]
+    text += 'response' + (e.dataPath || '') + ' ' + e.message + separator
+  }
+  return text.slice(0, -separator.length)
+}
+
+module.exports = fp(validateResponse)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fastify-response-validation",
   "version": "0.1.0",
-  "description": "",
+  "description": "A simple plugin that enables response validation for Fastify.",
   "main": "index.js",
   "dependencies": {
     "ajv": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "fastify-response-validation",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "ajv": "^6.11.0",
+    "fastify-plugin": "^1.6.0"
+  },
+  "devDependencies": {
+    "ava": "^3.1.0",
+    "fastify": "^2.11.0",
+    "standard": "^14.3.1"
+  },
+  "scripts": {
+    "test": "standard && ava -v"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastify/fastify-response-validation.git"
+  },
+  "keywords": [
+    "fastify",
+    "validation",
+    "response",
+    "json",
+    "schema"
+  ],
+  "author": "Tomas Della Vedova",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/fastify/fastify-response-validation/issues"
+  },
+  "homepage": "https://github.com/fastify/fastify-response-validation#readme"
+}

--- a/test.js
+++ b/test.js
@@ -100,3 +100,66 @@ test('Override default ajv options', async t => {
   t.is(response.statusCode, 200)
   t.deepEqual(JSON.parse(response.payload), { answer: 42 })
 })
+
+test('Disable response validation for a specific route', async t => {
+  const fastify = Fastify()
+  fastify.register(plugin)
+
+  fastify.route({
+    method: 'GET',
+    path: '/',
+    responseValidation: false,
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            answer: { type: 'number' }
+          }
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { answer: '42' }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.is(response.statusCode, 200)
+  t.deepEqual(JSON.parse(response.payload), { answer: 42 })
+})
+
+test('Disable response validation for every route', async t => {
+  const fastify = Fastify()
+  fastify.register(plugin, { responseValidation: false })
+
+  fastify.route({
+    method: 'GET',
+    path: '/',
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            answer: { type: 'number' }
+          }
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { answer: '42' }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.is(response.statusCode, 200)
+  t.deepEqual(JSON.parse(response.payload), { answer: 42 })
+})

--- a/test.js
+++ b/test.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const test = require('ava')
+const Fastify = require('fastify')
+const plugin = require('./')
+
+test('Should return a validation error', async t => {
+  const fastify = Fastify()
+  fastify.register(plugin)
+
+  fastify.route({
+    method: 'GET',
+    path: '/',
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            answer: { type: 'number' }
+          }
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { answer: '42' }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.is(response.statusCode, 500)
+  t.deepEqual(JSON.parse(response.payload), {
+    statusCode: 500,
+    error: 'Internal Server Error',
+    message: 'response.answer should be number'
+  })
+})
+
+test('Shoult check only the assigned status code', async t => {
+  const fastify = Fastify()
+  fastify.register(plugin)
+
+  fastify.route({
+    method: 'GET',
+    path: '/',
+    schema: {
+      response: {
+        '3xx': {
+          type: 'object',
+          properties: {
+            answer: { type: 'number' }
+          }
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { answer: '42' }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.is(response.statusCode, 200)
+  t.deepEqual(JSON.parse(response.payload), { answer: '42' })
+})
+
+test('Override default ajv options', async t => {
+  const fastify = Fastify()
+  fastify.register(plugin, { ajv: { coerceTypes: true } })
+
+  fastify.route({
+    method: 'GET',
+    path: '/',
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            answer: { type: 'number' }
+          }
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { answer: '42' }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/'
+  })
+
+  t.is(response.statusCode, 200)
+  t.deepEqual(JSON.parse(response.payload), { answer: 42 })
+})


### PR DESCRIPTION
This functionality has been asked multiple times in the past, and we made it clear that we don't want to support it in core.
Luckily, our API allows us to have it as external plugin ;)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)