### PR TITLE
feat: Supporting different content-type responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ app.inject({
 })
 ```
 
-Different content types responses are supported by `@fastify/response-validation`, `@fastify/swagger` and `@fastify`. Please use `content` for the response otherwise Fastify itself will fail to compile the schema:
+Different content types responses are supported by `@fastify/response-validation`, `@fastify/swagger` and `fastify`. Please use `content` for the response otherwise Fastify itself will fail to compile the schema:
 ```js
 {
   response: {

--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ app.inject({
 })
 ```
 
+Different content types responses are supported by `@fastify/response-validation`, `@fastify/swagger` and `@fastify`. Please use `content` for the response otherwise Fastify itself will fail to compile the schema:
+```js
+{
+  response: {
+    200: {
+      description: 'Description and all status-code based properties are working',
+      content: {
+        'application/json': {
+          schema: { 
+            name: { type: 'string' }, 
+            image: { type: 'string' }, 
+            address: { type: 'string' } 
+          }
+        }, 
+        'application/vnd.v1+json': {
+          schema: { 
+            fullName: { type: 'string' }, 
+            phone: { type: 'string' } 
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 If you want to override the default [ajv](https://www.npmjs.com/package/ajv) configuration, you can do that by using the `ajv` option:
 ```js
 // Default configuration:


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Closes #79 
