### PR TITLE
Fix issue with passing in non-draft 7 AJV instance. Issue 107

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@
 
 const fp = require('fastify-plugin')
 const Ajv = require('ajv')
+const AjvCore = require('ajv/dist/core')
 
 function fastifyResponseValidation (fastify, opts, next) {
   let ajv
-  if (opts.ajv && opts.ajv instanceof Ajv) {
+  if (opts.ajv && opts.ajv instanceof AjvCore.default) {
     ajv = opts.ajv
   } else {
     const { plugins: ajvPlugins, ...ajvOptions } = Object.assign({

--- a/test/ajv.test.js
+++ b/test/ajv.test.js
@@ -4,6 +4,8 @@ const test = require('tap').test
 const Fastify = require('fastify')
 const plugin = require('..')
 const Ajv = require('ajv')
+const Ajv2019 = require('ajv/dist/2019')
+const Ajv2020 = require('ajv/dist/2020')
 const ajvFormats = require('ajv-formats')
 const ajvErrors = require('ajv-errors')
 
@@ -138,6 +140,144 @@ test('use ajv formats with Ajv instance', async t => {
 test('use ajv errors with Ajv instance', async t => {
   const fastify = Fastify()
   const ajv = new Ajv({ allErrors: true })
+  ajvErrors(ajv, { singleError: true })
+  await fastify.register(plugin, { ajv })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          required: ['answer'],
+          properties: {
+            answer: { type: 'number' }
+          },
+          additionalProperties: false,
+          errorMessage: 'should be an object with an integer property answer only'
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { notAnAnswer: 24 }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.equal(response.statusCode, 500)
+  t.equal(response.json().message, 'response should be an object with an integer property answer only')
+})
+
+test('use ajv formats with 2019 Ajv instance', async t => {
+  const fastify = Fastify()
+  const ajv = new Ajv2019()
+  ajvFormats(ajv)
+  await fastify.register(plugin, { ajv })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            answer: { type: 'number', format: 'float' }
+          }
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { answer: 2.4 }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.strictSame(JSON.parse(response.payload), { answer: 2.4 })
+})
+
+test('use ajv errors with 2019 Ajv instance', async t => {
+  const fastify = Fastify()
+  const ajv = new Ajv2019({ allErrors: true })
+  ajvErrors(ajv, { singleError: true })
+  await fastify.register(plugin, { ajv })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          required: ['answer'],
+          properties: {
+            answer: { type: 'number' }
+          },
+          additionalProperties: false,
+          errorMessage: 'should be an object with an integer property answer only'
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { notAnAnswer: 24 }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.equal(response.statusCode, 500)
+  t.equal(response.json().message, 'response should be an object with an integer property answer only')
+})
+
+test('use ajv formats with 2020 Ajv instance', async t => {
+  const fastify = Fastify()
+  const ajv = new Ajv2020()
+  ajvFormats(ajv)
+  await fastify.register(plugin, { ajv })
+
+  fastify.route({
+    method: 'GET',
+    url: '/',
+    schema: {
+      response: {
+        '2xx': {
+          type: 'object',
+          properties: {
+            answer: { type: 'number', format: 'float' }
+          }
+        }
+      }
+    },
+    handler: async (req, reply) => {
+      return { answer: 2.4 }
+    }
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.strictSame(JSON.parse(response.payload), { answer: 2.4 })
+})
+
+test('use ajv errors with 2019 Ajv instance', async t => {
+  const fastify = Fastify()
+  const ajv = new Ajv2020({ allErrors: true })
   ajvErrors(ajv, { singleError: true })
   await fastify.register(plugin, { ajv })
 


### PR DESCRIPTION
Fixes issue 107 by using the base class of AJV to validate the AJV instance that is passed in.

(I don't usually use JavaScript, but I think this should solve my issue, since all AJV validators inherit from this class)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (No changes needed as one expects custom AJV instances to be supported in current documentation)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
