### PR TITLE
chore: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -14,17 +14,16 @@
     "@types/node": "^22.0.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0-alpha.3",
     "standard": "^17.1.0",
-    "tap": "^18.7.2",
     "tsd": "^0.31.0"
   },
   "scripts": {
     "lint": "standard",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
-    "test:typescript": "tsd",
-    "test:report": "tap --coverage-report=html -J test/test.js"
+    "test:unit": "c8 --100 node --test",
+    "test:typescript": "tsd"
   },
   "repository": {
     "type": "git",

--- a/test/ajv.test.js
+++ b/test/ajv.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const plugin = require('..')
 const Ajv = require('ajv')
@@ -36,8 +36,8 @@ test('use ajv formats', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 2.4 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 2.4 })
 })
 
 test('use ajv errors', async t => {
@@ -70,38 +70,63 @@ test('use ajv errors', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(JSON.parse(response.payload).message, 'response should be an object with an integer property answer only')
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(JSON.parse(response.payload).message, 'response should be an object with an integer property answer only')
 })
 
 test('should throw an error if ajv.plugins is string', async t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
-  t.rejects(async () => fastify.register(plugin, { ajv: { plugins: 'invalid' } }), 'ajv.plugins option should be an array, instead got \'string\'')
+  await t.assert.rejects(
+    async () => fastify.register(plugin, { ajv: { plugins: 'invalid' } }),
+    (err) => {
+      t.assert.strictEqual(err.message, 'ajv.plugins option should be an array, instead got \'string\'')
+      return true
+    })
 })
 
 test('should throw an error if ajv.plugins is null', async t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
-  t.rejects(async () => fastify.register(plugin, { ajv: { plugins: null } }), 'ajv.plugins option should be an array, instead got \'object\'')
+  await t.assert.rejects(
+    async () => fastify.register(plugin, { ajv: { plugins: null } }),
+    (err) => {
+      t.assert.strictEqual(err.message, 'ajv.plugins option should be an array, instead got \'object\'')
+      return true
+    })
 })
 
 test('should throw an error if ajv.plugins is undefined', async t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
-  t.rejects(async () => fastify.register(plugin, { ajv: { plugins: undefined } }), 'ajv.plugins option should be an array, instead got \'undefined\'')
+  await t.assert.rejects(
+    async () => fastify.register(plugin, { ajv: { plugins: undefined } }),
+    (err) => {
+      t.assert.strictEqual(err.message, 'ajv.plugins option should be an array, instead got \'undefined\'')
+      return true
+    })
 })
 
 test('should throw an error if ajv.plugins is boolean', async t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
-  t.rejects(async () => fastify.register(plugin, { ajv: { plugins: false } }), 'ajv.plugins option should be an array, instead got \'boolean\'')
+  await t.assert.rejects(
+    async () => fastify.register(plugin, { ajv: { plugins: false } }),
+    (err) => {
+      t.assert.strictEqual(err.message, 'ajv.plugins option should be an array, instead got \'boolean\'')
+      return true
+    })
 })
 
 test('should throw an error if ajv.plugins is number', async t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
-  t.rejects(async () => fastify.register(plugin, { ajv: { plugins: 0 } }), 'ajv.plugins option should be an array, instead got \'number\'')
+  await t.assert.rejects(
+    async () => fastify.register(plugin, { ajv: { plugins: 0 } }),
+    (err) => {
+      t.assert.strictEqual(err.message, 'ajv.plugins option should be an array, instead got \'number\'')
+      return true
+    })
 })
 
 test('use ajv formats with Ajv instance', async t => {
@@ -133,8 +158,8 @@ test('use ajv formats with Ajv instance', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 2.4 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 2.4 })
 })
 
 test('use ajv errors with Ajv instance', async t => {
@@ -169,8 +194,8 @@ test('use ajv errors with Ajv instance', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(response.json().message, 'response should be an object with an integer property answer only')
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(response.json().message, 'response should be an object with an integer property answer only')
 })
 
 test('use ajv formats with 2019 Ajv instance', async t => {
@@ -202,8 +227,8 @@ test('use ajv formats with 2019 Ajv instance', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 2.4 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 2.4 })
 })
 
 test('use ajv errors with 2019 Ajv instance', async t => {
@@ -238,8 +263,8 @@ test('use ajv errors with 2019 Ajv instance', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(response.json().message, 'response should be an object with an integer property answer only')
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(response.json().message, 'response should be an object with an integer property answer only')
 })
 
 test('use ajv formats with 2020 Ajv instance', async t => {
@@ -271,8 +296,8 @@ test('use ajv formats with 2020 Ajv instance', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 2.4 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 2.4 })
 })
 
 test('use ajv errors with 2019 Ajv instance', async t => {
@@ -307,12 +332,18 @@ test('use ajv errors with 2019 Ajv instance', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(response.json().message, 'response should be an object with an integer property answer only')
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(response.json().message, 'response should be an object with an integer property answer only')
 })
 
 test('should throw an error if ajv.plugins is not passed to instance and not array', async t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
-  t.rejects(async () => fastify.register(plugin, { ajv: { plugins: 'invalid' } }), 'ajv.plugins option should be an array, instead got \'string\'')
+  await t.assert.rejects(
+    async () => fastify.register(plugin, { ajv: { plugins: 'invalid' } }),
+    (err) => {
+      t.assert.strictEqual(err.message, 'ajv.plugins option should be an array, instead got \'string\'')
+      return true
+    }
+  )
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const plugin = require('..')
 
@@ -31,9 +31,9 @@ test('Should return a validation error', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
+  t.assert.strictEqual(response.statusCode, 500)
   const data = response.json()
-  t.strictSame(data, {
+  t.assert.deepStrictEqual(data, {
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'response/answer must be number'
@@ -64,8 +64,8 @@ test('Should support shortcut schema syntax', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.strictSame(JSON.parse(response.payload), {
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), {
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'response/answer must be number'
@@ -99,8 +99,8 @@ test('Should check only the assigned status code', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: '42' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: '42' })
 })
 
 test('Should check media types', async t => {
@@ -137,8 +137,8 @@ test('Should check media types', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.strictSame(JSON.parse(response.payload), {
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), {
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'No schema defined for media type application/not+json'
@@ -187,8 +187,8 @@ test('Should support media types', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 42 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 42 })
 })
 
 test('Should check anyOf Schema', async t => {
@@ -222,9 +222,9 @@ test('Should check anyOf Schema', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.equal(JSON.parse(response.payload).error, 'Internal Server Error')
-  t.equal(JSON.parse(response.payload).message, 'response/answer must be number, response must match a schema in anyOf')
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.strictEqual(JSON.parse(response.payload).error, 'Internal Server Error')
+  t.assert.strictEqual(JSON.parse(response.payload).message, 'response/answer must be number, response must match a schema in anyOf')
 })
 
 test('response validation is set, but no response schema given returns unvalidated response', async t => {
@@ -245,8 +245,8 @@ test('response validation is set, but no response schema given returns unvalidat
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: '42' })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: '42' })
 })
 
 test('Override default ajv options', async t => {
@@ -276,8 +276,8 @@ test('Override default ajv options', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 42 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 42 })
 })
 
 test('Disable response validation for a specific route', async t => {
@@ -308,8 +308,8 @@ test('Disable response validation for a specific route', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 42 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 42 })
 })
 
 test('Disable response validation for every route', async t => {
@@ -339,8 +339,8 @@ test('Disable response validation for every route', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 200)
-  t.strictSame(JSON.parse(response.payload), { answer: 42 })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), { answer: 42 })
 })
 
 test('Enable response status code validation for a specific route', async t => {
@@ -371,8 +371,8 @@ test('Enable response status code validation for a specific route', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.strictSame(JSON.parse(response.payload), {
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), {
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'No schema defined for status code 200'
@@ -406,8 +406,8 @@ test('Enable response status code validation for every route', async t => {
     url: '/'
   })
 
-  t.equal(response.statusCode, 500)
-  t.strictSame(JSON.parse(response.payload), {
+  t.assert.strictEqual(response.statusCode, 500)
+  t.assert.deepStrictEqual(JSON.parse(response.payload), {
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'No schema defined for status code 200'


### PR DESCRIPTION
#### Checklist

This PR migrate from tap to node:test and c8

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
