### PR TITLE
refactor: use `@fastify/error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,5 +158,13 @@ fastify.register(require('fastify-response-validation'), {
 })
 ```
 
+## Errors
+
+The errors emitted by this plugin are:
+
+- `FST_RESPONSE_VALIDATION_FAILED_VALIDATION`: This error is emitted when a response does not conform to the provided schema.
+
+- `FST_RESPONSE_VALIDATION_SCHEMA_NOT_DEFINED`: This error is emitted when there is no JSON schema available to validate the response.
+
 ## License
 [MIT](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "type": "commonjs",
   "dependencies": {
+    "@fastify/error": "^4.0.0",
     "ajv": "^8.12.0",
     "fastify-plugin": "^5.0.1"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,6 +34,7 @@ test('Should return a validation error', async t => {
   t.assert.strictEqual(response.statusCode, 500)
   const data = response.json()
   t.assert.deepStrictEqual(data, {
+    code: 'FST_RESPONSE_VALIDATION_FAILED_VALIDATION',
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'response/answer must be number'
@@ -66,6 +67,7 @@ test('Should support shortcut schema syntax', async t => {
 
   t.assert.strictEqual(response.statusCode, 500)
   t.assert.deepStrictEqual(JSON.parse(response.payload), {
+    code: 'FST_RESPONSE_VALIDATION_FAILED_VALIDATION',
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'response/answer must be number'
@@ -139,6 +141,7 @@ test('Should check media types', async t => {
 
   t.assert.strictEqual(response.statusCode, 500)
   t.assert.deepStrictEqual(JSON.parse(response.payload), {
+    code: 'FST_RESPONSE_VALIDATION_SCHEMA_NOT_DEFINED',
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'No schema defined for media type application/not+json'
@@ -373,6 +376,7 @@ test('Enable response status code validation for a specific route', async t => {
 
   t.assert.strictEqual(response.statusCode, 500)
   t.assert.deepStrictEqual(JSON.parse(response.payload), {
+    code: 'FST_RESPONSE_VALIDATION_SCHEMA_NOT_DEFINED',
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'No schema defined for status code 200'
@@ -408,6 +412,7 @@ test('Enable response status code validation for every route', async t => {
 
   t.assert.strictEqual(response.statusCode, 500)
   t.assert.deepStrictEqual(JSON.parse(response.payload), {
+    code: 'FST_RESPONSE_VALIDATION_SCHEMA_NOT_DEFINED',
     statusCode: 500,
     error: 'Internal Server Error',
     message: 'No schema defined for status code 200'


### PR DESCRIPTION
The aim of this PR is to address the issue https://github.com/fastify/fastify-response-validation/issues/121.

I’ve migrated the errors emitted by this plugin to use` @fastify/error`, which has enabled the creation of a utility function to check if the error is actually coming from this plugin by using the error code. This makes it easier for consumers to implement specific error-handling logic around it.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
