### PR TITLE
fix: support upper-case pattern and default response keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,11 +52,13 @@ function fastifyResponseValidation (fastify, opts, next) {
   function buildHook (schema, responseStatusCodeValidation) {
     const statusCodes = {}
     for (const originalCode in schema) {
-      // Internally we are going to treat status codes as lower-case strings to preserve compatibility
-      // with previous versions of this plugin allowing 4xx/5xx status codes to be defined as strings
-      // even though the OpenAPI spec requires them to be upper-case or the word 'default'.
-      // see: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#responses-object
-      // see also: https://swagger.io/specification/#fixed-fields-14
+      /**
+       * Internally we are going to treat status codes as lower-case strings to preserve compatibility
+       * with previous versions of this plugin allowing 4xx/5xx status codes to be defined as strings
+       * even though the OpenAPI spec requires them to be upper-case or the word 'default'.
+       * @see {@link https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#responses-object}
+       * @see {@link https://swagger.io/specification/#fixed-fields-14}
+       */
       const statusCode = originalCode.toLowerCase()
       const responseSchema = schema[originalCode]
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR is a possible [fix for issue-124](https://github.com/fastify/fastify-response-validation/issues/124) to support upper-case status code matching as well as the `default` key.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
