### PR TITLE
fix: assign schemas to host ajv instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function fastifyResponseValidation (fastify, opts, next) {
   }
 
   function onRoute (routeOpts) {
+    ajv.addSchema(Object.values(fastify.getSchemas()));
     if (routeOpts.responseValidation === false) return
     if (routeOpts.schema && routeOpts.schema.response) {
       const responseStatusCodeValidation = routeOpts.responseStatusCodeValidation || opts.responseStatusCodeValidation || false


### PR DESCRIPTION
Fixes the issue #113 by adding the schemas to the internal avj instance used by the plugin

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
